### PR TITLE
release_branch local variable isn't used

### DIFF
--- a/lib/capistrano/tasks/gitcopy.rake
+++ b/lib/capistrano/tasks/gitcopy.rake
@@ -4,7 +4,6 @@ namespace :gitcopy do
 
   # Deploy specific branch in the following way: 
   # $ cap deploy -s branch=<the branch you want to deploy>
-  release_branch = ENV["branch"] || "master"
 
   desc "Archive files to #{archive_name}"
   file archive_name do |file| 


### PR DESCRIPTION
As far as I can tell the release_branch local variable isn't used and that fetch(:branch) is used below. The documentation is correct still I believe.
