### PR TITLE
use the after hook to make sure to only cleanup the local file once

### DIFF
--- a/lib/capistrano/tasks/gitcopy.rake
+++ b/lib/capistrano/tasks/gitcopy.rake
@@ -26,14 +26,15 @@ namespace :gitcopy do
       execute :tar, "-xzf", tmp_file, "-C", release_path
       execute :rm, tmp_file
     end
-
-    Rake::Task["gitcopy:clean"].invoke
   end
+
 
   task :clean do |t|
     # Delete the local archive
     File.delete archive_name if File.exists? archive_name
   end
+  after 'deploy:finished', 'gitcopy:clean'
+
 
   task :create_release => :deploy
 


### PR DESCRIPTION
currently if you are deploying to multiple servers you can run into a race condition where the if File.exists? in the clean task returns true but then the OS will error when actually removing.

Capistrano supports before/after hooks - so use those to maintain threadsafety.
