### PR TITLE
Update gitcopy.rake

### DIFF
--- a/lib/capistrano/tasks/gitcopy.rake
+++ b/lib/capistrano/tasks/gitcopy.rake
@@ -8,7 +8,7 @@ namespace :gitcopy do
 
   desc "Archive files to #{archive_name}"
   file archive_name do |file| 
-    system "git archive #{ fetch(:branch) } --format tar.gz --output #{ archive_name }"
+    system "git archive --format=tar #{ fetch(:branch) } | gzip > #{ archive_name }"
   end
 
   desc "Deploy #{archive_name} to release_path"


### PR DESCRIPTION
- [x] Output into file fixed, your version only did a print out onto the screen (git archive issues). 
- [x] Format parameter of git archive fixed, some machine or git archive version could only accept the format parameter in the front.
