### PR TITLE
Add support for specifying a remote branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [ capistrano-scm-gitcopy ](https://github.com/xuwupeng2000/capsitrano-scm-gitcopy)
 ===================
 
-Capistrano 3 :copy 
+Capistrano 3 :copy
 
 A copy strategy for Capistrano 3, which mimics the `:copy` scm of Capistrano 2.
 This Gem is inspired by and based on https://github.com/wercker/capistrano-scm-copy.
@@ -32,11 +32,11 @@ First make sure you install the capistrano-scm-gitcopy by adding it to your `Gem
 Then switch the `:scm` option to `:gitcopy` in `config/deploy.rb`:
 
     set :scm, :gitcopy
-    
+
 
 Usage
 ============
 
 ```bash
-  cap uat deploy -s branch=(your release branch)
+  cap uat deploy -s branch=(your release branch) -s remote=(your remote)
   ```

--- a/lib/capistrano/tasks/gitcopy.rake
+++ b/lib/capistrano/tasks/gitcopy.rake
@@ -1,12 +1,12 @@
 namespace :gitcopy do
 
-  archive_name =  "archive.#{ DateTime.now.strftime('%Y%m%d%m%s') }.tar.gz" 
+  archive_name =  "archive.#{ DateTime.now.strftime('%Y%m%d%m%s') }.tar.gz"
 
   desc "Archive files to #{archive_name}"
-  file archive_name do |file| 
-    system "git ls-remote #{fetch(:repo_url)} | grep #{fetch(:branch)}"
+  file archive_name do |file|
+    system "git ls-remote #{fetch(:repo_url)} | grep #{fetch(:remote, 'origin')}/#{fetch(:branch)}"
     if $?.exitstatus == 0
-      system "git archive --remote #{fetch(:repo_url)} --format=tar #{fetch(:branch)} | gzip > #{ archive_name }"
+      system "git archive --remote #{fetch(:repo_url)} --format=tar #{fetch(:remote, 'origin')}/#{fetch(:branch)} | gzip > #{ archive_name }"
     else
       puts "Can't find commit for: #{fetch(:branch)}"
     end


### PR DESCRIPTION
When using scm-gitcopy on our GitLab CI server, it's not able to function without specifying the remote along with the branch because ls-remote fails.

Configured to default to origin if no remote is specified.
