### PR TITLE
Add possibility to have tmp_dir_remote

### DIFF
--- a/lib/capistrano/gitcopy.rb
+++ b/lib/capistrano/gitcopy.rb
@@ -47,7 +47,7 @@ class Capistrano::GitCopy < Capistrano::SCM
     end
 
     def remote_tarfile
-      "#{fetch(:tmp_dir)}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
+      "#{fetch(:tmp_dir_remote, fetch(:tmp_dir))}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
     end
 
     def release


### PR DESCRIPTION
Hey there,

i'd like to discuss the following issues by using the :tmp_dir with the current implementation. Also i'd like to suggest a solution to the underlying problem.

1. I cannot rely on using the default :tmp_dir (/tmp) because we use the noexec-flag on that directory on our deployment machine. I'll get a "Permission denied" when I try to execute the /tmp/git-ssh.sh.
2. I cannot rely on setting a different :tmp_dir because it will be used to build both the local_tarfile name and the remote_tarfile name. I cannot think of a path that is available, writeable and executable on both the local and the remote machine.

As one possible solution I'd like to suggest to introduce a :tmp_dir_remote. Any other ideas?