### PR TITLE
Update to use new Capistrano SCM format and enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ Usage
 ```bash
   bundle exec cap staging deploy branch=(your release branch)
   ```
+
+Output is quiet by default set `gitcopy_verbose` to true in order get verbose output
+
+```
+set :gitcopy_verbose, true
+```

--- a/lib/capistrano/gitcopy.rb
+++ b/lib/capistrano/gitcopy.rb
@@ -47,7 +47,7 @@ class Capistrano::GitCopy < Capistrano::SCM::Plugin
   end
 
   def fetch_revision
-    backend.capture(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 #{fetch(:branch)}")
+    backend.capture(:git, "rev-list --max-count=1 #{fetch(:branch)}")
   end
 
   def local_tarfile

--- a/lib/capistrano/gitcopy.rb
+++ b/lib/capistrano/gitcopy.rb
@@ -1,63 +1,70 @@
-load File.expand_path('../tasks/gitcopy.rake', __FILE__)
+require 'capistrano/scm/plugin'
 
-require 'capistrano/scm'
-
-set_if_empty :local_path, -> { "/tmp/#{fetch(:application)}-repository/#{Time.now.to_i}" }
-
-class Capistrano::GitCopy < Capistrano::SCM
+class Capistrano::GitCopy < Capistrano::SCM::Plugin
 
   # execute git with argument in the context
   #
   def git(*args)
     args.unshift :git
-    context.execute(*args)
+    backend.execute(*args)
   end
 
-  module DefaultStrategy
+  def set_defaults
+    set_if_empty :local_path, -> { "/tmp/#{fetch(:application)}-repository/#{Time.now.to_i}" }
+  end
 
-    def check
-      git :'ls-remote --heads', repo_url
+  def register_hooks
+    after "deploy:new_release_path", "gitcopy:create_release"
+    before "deploy:check", "gitcopy:check"
+    before "deploy:set_current_revision", "gitcopy:set_current_revision"
+  end
+
+  def define_tasks
+    eval_rakefile File.expand_path('../tasks/gitcopy.rake', __FILE__)
+  end
+
+  def check
+    git :'ls-remote --heads', repo_url
+  end
+
+  def clone
+    local_path = fetch(:local_path)
+
+    if (depth = fetch(:git_shallow_clone))
+      git :clone, '--verbose', '--mirror', '--depth', depth, '--no-single-branch', repo_url, local_path
+    else
+      git :clone, '--verbose', '--mirror', repo_url, local_path
     end
+  end
 
-    def clone
-      local_path = fetch(:local_path)
-
-      if (depth = fetch(:git_shallow_clone))
-        git :clone, '--verbose', '--mirror', '--depth', depth, '--no-single-branch', repo_url, local_path
-      else
-        git :clone, '--verbose', '--mirror', repo_url, local_path
-      end
+  def update
+    # Note: Requires git version 1.9 or greater
+    if (depth = fetch(:git_shallow_clone))
+      git :fetch, '--depth', depth, 'origin', fetch(:branch)
+    else
+      git :remote, :update
     end
+  end
 
-    def update
-      # Note: Requires git version 1.9 or greater
-      if (depth = fetch(:git_shallow_clone))
-        git :fetch, '--depth', depth, 'origin', fetch(:branch)
-      else
-        git :remote, :update
-      end
-    end
+  def fetch_revision
+    backend.capture(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 #{fetch(:branch)}")
+  end
 
-    def fetch_revision
-      context.capture(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 #{fetch(:branch)}")
-    end
+  def local_tarfile
+    "#{fetch(:tmp_dir)}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
+  end
 
-    def local_tarfile
-      "#{fetch(:tmp_dir)}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
-    end
+  def remote_tarfile
+    "#{fetch(:tmp_dir_remote, fetch(:tmp_dir))}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
+  end
 
-    def remote_tarfile
-      "#{fetch(:tmp_dir_remote, fetch(:tmp_dir))}/#{fetch(:application)}-#{fetch(:current_revision).strip}.tar.gz"
-    end
-
-    def release
-      if (tree = fetch(:repo_tree))
-        tree = tree.slice %r#^/?(.*?)/?$#, 1
-        components = tree.split('/').size
-        git :archive, fetch(:branch), tree, '--format', 'tar', "|gzip > #{local_tarfile}"
-      else
-        git :archive, fetch(:branch), '--format', 'tar', "|gzip > #{local_tarfile}"
-      end
+  def release
+    if (tree = fetch(:repo_tree))
+      tree = tree.slice %r#^/?(.*?)/?$#, 1
+      components = tree.split('/').size
+      git :archive, fetch(:branch), tree, '--format', 'tar', "|gzip > #{local_tarfile}"
+    else
+      git :archive, fetch(:branch), '--format', 'tar', "|gzip > #{local_tarfile}"
     end
   end
 

--- a/lib/capistrano/gitcopy.rb
+++ b/lib/capistrano/gitcopy.rb
@@ -24,16 +24,16 @@ class Capistrano::GitCopy < Capistrano::SCM::Plugin
   end
 
   def check
-    git :'ls-remote --heads', repo_url
+    git :'ls-remote --heads', repo_url, fetch(:gitcopy_verbose) ? '' : '> /dev/null'
   end
 
   def clone
     local_path = fetch(:local_path)
 
     if (depth = fetch(:git_shallow_clone))
-      git :clone, '--verbose', '--mirror', '--depth', depth, '--no-single-branch', repo_url, local_path
+      git :clone, fetch(:gitcopy_verbose) ? '--verbose' : '--quiet', '--mirror', '--depth', depth, '--no-single-branch', repo_url, local_path
     else
-      git :clone, '--verbose', '--mirror', repo_url, local_path
+      git :clone, fetch(:gitcopy_verbose) ? '--verbose' : '--quiet', '--mirror', repo_url, local_path
     end
   end
 

--- a/lib/capistrano/tasks/gitcopy.rake
+++ b/lib/capistrano/tasks/gitcopy.rake
@@ -1,8 +1,6 @@
-namespace :gitcopy do
+strategy = self
 
-  def strategy
-    @strategy ||= Capistrano::GitCopy.new(self, fetch(:git_strategy, Capistrano::GitCopy::DefaultStrategy))
-  end
+namespace :gitcopy do
 
   set :git_environmental_variables, ->() {
     {

--- a/lib/capistrano/tasks/gitcopy.rake
+++ b/lib/capistrano/tasks/gitcopy.rake
@@ -78,7 +78,8 @@ namespace :gitcopy do
     on release_roles :all do
       within deploy_to do
         execute :mkdir, '-p', release_path
-        extract_option = ["--extract", "--verbose"]
+        extract_option = ["--extract"]
+        extract_option << '--verbose' if fetch(:gitcopy_verbose)
         if (tree = fetch(:repo_tree))
           tree = tree.slice %r#^/?(.*?)/?$#, 1
           components = tree.split("/").size


### PR DESCRIPTION
* fixes deprecation warnings from recent capistrano changes
* add verbose option and by default suppress output
* fix revision string to be inline with existing git scm revisions